### PR TITLE
Remove Redundant Nix Flake Dependency

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -33,7 +33,6 @@
           packages = with pkgs; [
             # JS / frontend
             nodejs
-            nodePackages.npm
 
             # Rust extras
             rust-analyzer


### PR DESCRIPTION
`npm` was redundant since it already comes with `nodejs` and in this case was causing a full rebuild when unnecessary.