### PR TITLE
Prevent Wrapping Every Event Json in Event Name

### DIFF
--- a/server/src/event.rs
+++ b/server/src/event.rs
@@ -7,6 +7,7 @@ use serde::Serialize;
 type Username = String;
 
 #[derive(Clone, Serialize)]
+#[serde(untagged)]
 pub enum RoomEvent {
     RoundStart(PanoId),
     RoundEnd(RoundData),


### PR DESCRIPTION
@Canyon-C 

Instead of

```
{
  RoundData: {
    real_location: ...,
    player_results: ...,
  },
}
```

its just

```
{
  real_location: ...,
  player_results: ...
}
```