### PR TITLE
(fix): Clean Stale Rooms

### DIFF
--- a/server/src/context.rs
+++ b/server/src/context.rs
@@ -30,14 +30,57 @@ pub struct Model {
 impl Context {
     /// Create an empty context.
     pub fn new(engine: LocationEngine) -> Self {
+        let model = Arc::new(RwLock::new(Model::default()));
+
+        // Spawn a background task to periodically clean up stale rooms.
+        let model_clone = model.clone();
+        tokio::spawn(async move {
+            let mut interval = tokio::time::interval(std::time::Duration::from_secs(30));
+            loop {
+                interval.tick().await;
+                let mut model = model_clone.write().await;
+                model.cleanup_stale_rooms();
+            }
+        });
+
         Self {
             engine: Arc::new(engine),
-            model: Arc::new(RwLock::new(Model::default())),
+            model,
         }
     }
 }
 
 impl Model {
+    pub fn cleanup_stale_rooms(&mut self) {
+        tracing::debug!(
+            "running stale room cleanup ({} rooms active)",
+            self.rooms.len()
+        );
+        let stale_room_ids: Vec<_> = self
+            .rooms
+            .iter()
+            .filter(|(_, room)| room.is_stale())
+            .map(|(id, _)| id.clone())
+            .collect();
+
+        for id in stale_room_ids {
+            tracing::info!(room_id = %id.as_ref(), "cleaning up stale room");
+            if let Some(_room) = self.rooms.remove(&id) {
+                // Also remove all clients that were in this room
+                let client_ids: Vec<_> = self
+                    .clients
+                    .iter()
+                    .filter(|(_, handle)| handle.room == id)
+                    .map(|(id, _)| id.clone())
+                    .collect();
+                for client_id in client_ids {
+                    tracing::debug!(client_id = %*client_id, "removing client from stale room");
+                    self.clients.remove(&client_id);
+                }
+            }
+        }
+    }
+
     pub fn generate_unique_name(&self) -> String {
         let mut name = self.name_generator.generate();
         // Check for collisions across all existing clients.
@@ -154,6 +197,9 @@ impl Model {
         username: String,
         color_override: Option<String>,
     ) -> (room::Id, String) {
+        // Ensure the client is removed from any existing rooms before creating a new one.
+        self.remove_client(&client_id);
+
         // Generate room Id (ensure no collisions)
         let room_id = {
             let mut id = room::Id::random();
@@ -162,6 +208,8 @@ impl Model {
             }
             id
         };
+
+        tracing::info!(room_id = %room_id.as_ref(), username = %username, "created new room");
 
         // Create room + handle
         let room = Room::new(

--- a/server/src/geo.rs
+++ b/server/src/geo.rs
@@ -7,6 +7,7 @@ pub mod streetview;
 
 pub type PanoId = String;
 
+#[derive(Clone)]
 pub struct Location {
     pub coordinates: Coordinates,
     pub pano_id: PanoId,

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -3,13 +3,13 @@ pub mod config;
 pub mod context;
 mod event;
 pub mod geo;
-mod handle;
+pub mod handle;
 pub mod name_gen;
-mod room;
+pub mod room;
 pub mod routes;
 mod score;
 
-pub use context::Context;
+pub use context::{Context, Model};
 pub use event::RoomEvent;
 pub use geo::Coordinates;
 pub use handle::Handle;

--- a/server/src/room.rs
+++ b/server/src/room.rs
@@ -31,6 +31,10 @@ pub struct Room {
     config: Config,
     /// The event sender handle for the room, used to broadcast events to all members of the room.
     pub event_tx: broadcast::Sender<RoomEvent>,
+    /// The number of active SSE connections to this room.
+    pub active_connections: usize,
+    /// The last time there was activity in this room (connection or creation).
+    pub last_activity: std::time::Instant,
     // TODO: location history for the round
 }
 
@@ -55,7 +59,24 @@ impl Room {
             colors,
             config: Config {},
             event_tx,
+            active_connections: 0,
+            last_activity: std::time::Instant::now(),
         }
+    }
+
+    pub fn increment_connection(&mut self) {
+        self.active_connections += 1;
+        self.last_activity = std::time::Instant::now();
+    }
+
+    pub fn decrement_connection(&mut self) {
+        self.active_connections = self.active_connections.saturating_sub(1);
+        self.last_activity = std::time::Instant::now();
+    }
+
+    pub fn is_stale(&self) -> bool {
+        self.active_connections == 0
+            && self.last_activity.elapsed() > std::time::Duration::from_secs(60)
     }
 
     /// Add a member to the room. If `color` is not provided, a new distinct color is generated.
@@ -65,6 +86,7 @@ impl Room {
         username: String,
         color_override: Option<String>,
     ) {
+        self.last_activity = std::time::Instant::now();
         let occupied: Vec<MemberColor> = self.members.values().map(|m| m.color.clone()).collect();
         let color = match color_override {
             Some(c) => MemberColor::Custom(c),
@@ -83,6 +105,7 @@ impl Room {
     }
 
     pub fn remove_member(&mut self, client_id: &handle::Id) {
+        self.last_activity = std::time::Instant::now();
         let Some(member) = self.members.remove(client_id) else {
             return;
         };
@@ -100,6 +123,7 @@ impl Room {
     /// Handle a ready submission from a member of the room.
     /// Returns true if everyone is ready.
     pub fn submit_ready(&mut self, client_id: &handle::Id) -> bool {
+        self.last_activity = std::time::Instant::now();
         let Some(member) = self.members.get_mut(client_id) else {
             return false;
         };
@@ -111,6 +135,7 @@ impl Room {
 
     /// Transition to next round
     pub fn start_next_round(&mut self, new_location: Location) {
+        self.last_activity = std::time::Instant::now();
         let pano_id = new_location.pano_id.clone();
         self.location = new_location;
 
@@ -129,6 +154,7 @@ impl Room {
     /// Handle a guess from a member of the room. This will update the member's score and broadcast
     /// if everyone has submitted a guess for the current round.
     pub fn submit_guess(&mut self, client_id: &handle::Id, guess: Coordinates) {
+        self.last_activity = std::time::Instant::now();
         let Some(member) = self.members.get_mut(client_id) else {
             return;
         };

--- a/server/src/routes/events.rs
+++ b/server/src/routes/events.rs
@@ -8,7 +8,7 @@ use axum::{
 use futures_util::{Stream, StreamExt};
 use tokio_stream::wrappers::BroadcastStream;
 
-use crate::{Context, RoomEvent, context::SharedModel, event::RoundStartData, handle};
+use crate::{Context, RoomEvent, context::SharedModel, event::RoundStartData, handle, room};
 
 #[pin_project::pin_project(PinnedDrop)]
 pub struct EventStream<S> {
@@ -17,6 +17,7 @@ pub struct EventStream<S> {
 
     model: SharedModel,
     client_id: handle::Id,
+    room_id: room::Id,
 }
 
 impl<S: Stream> Stream for EventStream<S> {
@@ -35,11 +36,27 @@ impl<S> PinnedDrop for EventStream<S> {
     fn drop(self: Pin<&mut Self>) {
         let state = self.model.clone();
         let client_id = self.client_id.clone();
+        let room_id = self.room_id.clone();
 
         tokio::spawn(async move {
             let mut state = state.write().await;
-            state.remove_client(&client_id);
-            tracing::info!(client_id = %*client_id, "client disconnected, removed from room");
+
+            if let Some(room) = state.rooms.get_mut(&room_id) {
+                room.decrement_connection();
+            }
+
+            // Only remove the client if they are still in the room this stream was for.
+            // This prevents a stale connection from an old room kicking a player out of their new room.
+            let is_in_room = state
+                .clients
+                .get(&client_id)
+                .map(|h| h.room == room_id)
+                .unwrap_or(false);
+
+            if is_in_room {
+                state.remove_client(&client_id);
+                tracing::info!(client_id = %*client_id, "client disconnected, removed from room");
+            }
         });
     }
 }
@@ -49,13 +66,15 @@ pub async fn sse_event_handler(
     State(context): State<Context>,
     client_id: handle::Id,
 ) -> Result<Sse<impl Stream<Item = Result<sse::Event, axum::Error>>>, StatusCode> {
-    let model = context.model.read().await;
+    let mut model = context.model.write().await;
     let handle = model
         .clients
         .get(&client_id)
         .ok_or(StatusCode::UNAUTHORIZED)?;
     let room_id = handle.room.clone();
-    let room = model.rooms.get(&room_id).ok_or(StatusCode::NOT_FOUND)?;
+    let room = model.rooms.get_mut(&room_id).ok_or(StatusCode::NOT_FOUND)?;
+
+    room.increment_connection();
 
     let round = room.round;
     let pano_id = room.location.pano_id.clone();
@@ -76,6 +95,7 @@ pub async fn sse_event_handler(
         stream: broadcast_stream,
         model: context.model.clone(),
         client_id: client_id.clone(),
+        room_id,
     };
 
     room.event_tx.send(initial_event).unwrap();

--- a/server/tests/leak_test.rs
+++ b/server/tests/leak_test.rs
@@ -1,0 +1,86 @@
+use ryguessr::{
+    Model,
+    geo::{Coordinates, Location},
+    handle,
+};
+use std::time::{Duration, Instant};
+
+#[tokio::test]
+async fn test_room_leak_on_reinit() {
+    let mut model = Model::default();
+    let client_id = handle::Id::generate();
+    let location = Location {
+        pano_id: "pano".to_string(),
+        coordinates: Coordinates { lat: 0.0, lng: 0.0 },
+    };
+
+    model.create_room(
+        location.clone(),
+        client_id.clone(),
+        "test".to_string(),
+        None,
+    );
+    assert_eq!(model.rooms.len(), 1, "Should have 1 room initially");
+
+    // Re-init with same client_id
+    model.create_room(location, client_id.clone(), "test".to_string(), None);
+
+    // If it leaks, this will be 2
+    assert_eq!(
+        model.rooms.len(),
+        1,
+        "Should still have only 1 room, old one should be cleaned up"
+    );
+}
+
+#[tokio::test]
+async fn test_stale_room_cleanup() {
+    let mut model = Model::default();
+    let client_id = handle::Id::generate();
+    let location = Location {
+        pano_id: "pano".to_string(),
+        coordinates: Coordinates { lat: 0.0, lng: 0.0 },
+    };
+
+    let (room_id, _) = model.create_room(location, client_id.clone(), "test".to_string(), None);
+    assert_eq!(model.rooms.len(), 1);
+    assert_eq!(model.clients.len(), 1);
+
+    // Manually set last_activity to 61 seconds ago
+    if let Some(room) = model.rooms.get_mut(&room_id) {
+        room.last_activity = Instant::now() - Duration::from_secs(61);
+    }
+
+    // Cleanup should remove it
+    model.cleanup_stale_rooms();
+
+    assert_eq!(model.rooms.len(), 0, "Stale room should be cleaned up");
+    assert_eq!(
+        model.clients.len(),
+        0,
+        "Client associated with stale room should be cleaned up"
+    );
+}
+
+#[tokio::test]
+async fn test_active_room_not_cleaned_up() {
+    let mut model = Model::default();
+    let client_id = handle::Id::generate();
+    let location = Location {
+        pano_id: "pano".to_string(),
+        coordinates: Coordinates { lat: 0.0, lng: 0.0 },
+    };
+
+    let (room_id, _) = model.create_room(location, client_id.clone(), "test".to_string(), None);
+
+    // Set active connection and old last_activity
+    if let Some(room) = model.rooms.get_mut(&room_id) {
+        room.increment_connection();
+        room.last_activity = Instant::now() - Duration::from_secs(61);
+    }
+
+    // Cleanup should NOT remove it
+    model.cleanup_stale_rooms();
+
+    assert_eq!(model.rooms.len(), 1, "Active room should NOT be cleaned up");
+}


### PR DESCRIPTION
Keep track of room activity and sse connections to periodically clean any rooms that aren't active and did not get dropped on their own.

Closes #39 