### PR TITLE
Support for inactive (lobby) rooms

### DIFF
--- a/server/src/context.rs
+++ b/server/src/context.rs
@@ -1,11 +1,10 @@
 use std::{collections::HashMap, sync::Arc, time::Duration};
 
-use axum::http::StatusCode;
 use colors::Srgb8;
 use tokio::sync::RwLock;
 
 use crate::{
-    Handle, Room, RoomEvent,
+    AppError, Handle, Room, RoomEvent,
     colors::PlayerColor,
     event::PlayerData,
     geo::{Location, engine::LocationEngine},
@@ -80,7 +79,7 @@ impl Context {
         &self,
         client_id: &handle::Id,
         new_room_id: &room::Id,
-    ) -> Result<Vec<PlayerData>, StatusCode> {
+    ) -> Result<Vec<PlayerData>, AppError> {
         let mut model = self.model.write().await;
         model.move_client_to_room(client_id, new_room_id)?;
 
@@ -122,10 +121,7 @@ impl Context {
         (room_id, username, color)
     }
 
-    pub async fn get_room_players(
-        &self,
-        room_id: &room::Id,
-    ) -> Result<Vec<PlayerData>, StatusCode> {
+    pub async fn get_room_players(&self, room_id: &room::Id) -> Result<Vec<PlayerData>, AppError> {
         let model = self.model.read().await;
         Ok(model.room(room_id)?.players())
     }
@@ -166,24 +162,24 @@ impl Model {
         &mut self,
         client_id: &handle::Id,
         new_username: String,
-    ) -> Result<(), StatusCode> {
+    ) -> Result<(), AppError> {
         // Check for name collision across all existing clients.
         if self.clients.values().any(|c| c.username == new_username) {
-            return Err(StatusCode::CONFLICT);
+            return Err(AppError::UsernameTaken);
         }
 
         // Update the client's name in the model.
         let handle = self
             .clients
             .get_mut(client_id)
-            .ok_or(StatusCode::UNAUTHORIZED)?;
+            .ok_or(AppError::UnknownClient)?;
         handle.username = new_username.clone();
 
         // Update the client's name in their current room.
         let room = self
             .rooms
             .get_mut(&handle.room)
-            .ok_or(StatusCode::NOT_FOUND)?;
+            .ok_or(AppError::RoomNotFound)?;
         if let Some(member) = room.members.get_mut(client_id) {
             let old_username = member.username.clone();
             member.username = new_username.clone();
@@ -198,15 +194,12 @@ impl Model {
         Ok(())
     }
 
-    pub fn set_color(
-        &mut self,
-        client_id: &handle::Id,
-        new_color: Srgb8,
-    ) -> Result<(), StatusCode> {
+    pub fn set_color(&mut self, client_id: &handle::Id, new_color: Srgb8) -> Result<(), AppError> {
         let handle = self
             .clients
             .get_mut(client_id)
-            .ok_or(StatusCode::UNAUTHORIZED)?;
+            .ok_or(AppError::UnknownClient)?;
+
         handle.color = PlayerColor {
             srgb: new_color,
             custom: true,
@@ -216,7 +209,7 @@ impl Model {
         let room = self
             .rooms
             .get_mut(&handle.room)
-            .ok_or(StatusCode::NOT_FOUND)?;
+            .ok_or(AppError::RoomNotFound)?;
         if let Some(member) = room.members.get_mut(client_id) {
             // Free the prior color so a future distinct pick can reuse it,
             // then register the new custom pick so picks stay clear of it.
@@ -234,34 +227,31 @@ impl Model {
         Ok(())
     }
 
-    pub fn client_room_mut(&mut self, client_id: &handle::Id) -> Result<&mut Room, StatusCode> {
+    pub fn client_room_mut(&mut self, client_id: &handle::Id) -> Result<&mut Room, AppError> {
         let room_id = self
             .clients
             .get(client_id)
-            .ok_or(StatusCode::UNAUTHORIZED)?
+            .ok_or(AppError::UnknownClient)?
             .room
             .clone();
 
         self.room_mut(&room_id)
     }
 
-    pub fn room(&self, room_id: &room::Id) -> Result<&Room, StatusCode> {
-        self.rooms.get(room_id).ok_or(StatusCode::NOT_FOUND)
+    pub fn room(&self, room_id: &room::Id) -> Result<&Room, AppError> {
+        self.rooms.get(room_id).ok_or(AppError::RoomNotFound)
     }
 
-    pub fn room_mut(&mut self, room_id: &room::Id) -> Result<&mut Room, StatusCode> {
-        self.rooms.get_mut(room_id).ok_or(StatusCode::NOT_FOUND)
+    pub fn room_mut(&mut self, room_id: &room::Id) -> Result<&mut Room, AppError> {
+        self.rooms.get_mut(room_id).ok_or(AppError::RoomNotFound)
     }
 
     pub fn move_client_to_room(
         &mut self,
         client_id: &handle::Id,
         new_room_id: &room::Id,
-    ) -> Result<(), StatusCode> {
-        let handle = self
-            .clients
-            .get(client_id)
-            .ok_or(StatusCode::UNAUTHORIZED)?;
+    ) -> Result<(), AppError> {
+        let handle = self.clients.get(client_id).ok_or(AppError::UnknownClient)?;
 
         if &handle.room == new_room_id {
             return Ok(());
@@ -269,7 +259,7 @@ impl Model {
 
         // Validate new room exists before making any changes
         if !self.rooms.contains_key(new_room_id) {
-            return Err(StatusCode::NOT_FOUND);
+            return Err(AppError::RoomNotFound);
         }
 
         let username = handle.username.clone();

--- a/server/src/error.rs
+++ b/server/src/error.rs
@@ -1,0 +1,40 @@
+use axum::{
+    http::StatusCode,
+    response::{IntoResponse, Response},
+};
+
+#[derive(Debug)]
+pub enum AppError {
+    /// The request's client id is not registered (no init / expired room).
+    UnknownClient,
+    /// The addressed room does not exist.
+    RoomNotFound,
+    /// The action requires `State::Active` but the room is `State::Inactive`.
+    RoomInactive,
+    /// The requested username is already in use by another client.
+    UsernameTaken,
+    /// Anything unexpected — surfaced as 500, logged on the way out.
+    Internal(anyhow::Error),
+}
+
+impl IntoResponse for AppError {
+    fn into_response(self) -> Response {
+        if let AppError::Internal(err) = &self {
+            tracing::error!(error = %err, "internal server error");
+        }
+        let (status, message) = match self {
+            AppError::UnknownClient => (StatusCode::UNAUTHORIZED, "unknown client"),
+            AppError::RoomNotFound => (StatusCode::NOT_FOUND, "room not found"),
+            AppError::RoomInactive => (StatusCode::CONFLICT, "room is inactive"),
+            AppError::UsernameTaken => (StatusCode::CONFLICT, "username already taken"),
+            AppError::Internal(_) => (StatusCode::INTERNAL_SERVER_ERROR, "internal server error"),
+        };
+        (status, message).into_response()
+    }
+}
+
+impl From<anyhow::Error> for AppError {
+    fn from(err: anyhow::Error) -> Self {
+        AppError::Internal(err)
+    }
+}

--- a/server/src/event.rs
+++ b/server/src/event.rs
@@ -12,8 +12,8 @@ type Username = String;
 pub enum RoomEvent {
     RoundStart(RoundStartData),
     RoundEnd(RoundEndData),
-    PlayerJoined(PlayerData),
-    PlayerLeft {
+    PlayerJoin(PlayerData),
+    PlayerLeave {
         username: Username,
     },
     ChangeName {
@@ -24,6 +24,7 @@ pub enum RoomEvent {
         username: Username,
         color: Srgb8,
     },
+    Deactivate,
 }
 
 impl TryFrom<RoomEvent> for sse::Event {

--- a/server/src/event.rs
+++ b/server/src/event.rs
@@ -37,7 +37,7 @@ impl TryFrom<RoomEvent> for sse::Event {
 #[derive(Debug, Clone, Serialize)]
 pub struct RoundStartData {
     pub pano_id: PanoId,
-    pub round: usize,
+    pub round: u32,
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/server/src/handle.rs
+++ b/server/src/handle.rs
@@ -3,7 +3,7 @@ use axum_extra::extract::{CookieJar, cookie::Cookie};
 use derive_more::{AsRef, Deref};
 use uuid::Uuid;
 
-use crate::{colors::PlayerColor, room};
+use crate::{AppError, colors::PlayerColor, room};
 
 /// A handle to a particular client.
 pub struct Handle {
@@ -45,7 +45,7 @@ impl TryFrom<&str> for Id {
 }
 
 impl<S: Send + Sync> FromRequestParts<S> for Id {
-    type Rejection = StatusCode;
+    type Rejection = AppError;
 
     async fn from_request_parts(
         parts: &mut axum::http::request::Parts,
@@ -53,10 +53,10 @@ impl<S: Send + Sync> FromRequestParts<S> for Id {
     ) -> Result<Self, Self::Rejection> {
         let jar = CookieJar::from_request_parts(parts, state)
             .await
-            .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+            .map_err(|e| AppError::Internal(anyhow::anyhow!("cookie jar extraction: {e}")))?;
 
         jar.get(ID_COOKIE_NAME)
             .map(|c| Id(c.value().to_string()))
-            .ok_or(StatusCode::UNAUTHORIZED)
+            .ok_or(AppError::UnknownClient)
     }
 }

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod colors;
 pub mod config;
 pub mod context;
+pub mod error;
 mod event;
 pub mod geo;
 pub mod handle;
@@ -10,6 +11,7 @@ pub mod routes;
 mod score;
 
 pub use context::{Context, Model};
+pub use error::AppError;
 pub use event::RoomEvent;
 pub use geo::Coordinates;
 pub use handle::Handle;

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -46,6 +46,10 @@ async fn main() -> anyhow::Result<()> {
         .route("/api/guess", post(routes::guess::guess_handler))
         .route("/api/next", post(routes::next::next_handler))
         .route("/api/join", post(routes::join::join_handler))
+        .route(
+            "/api/deactivate",
+            post(routes::deactivate::deactivate_handler),
+        )
         .route("/api/username", post(routes::username::username_handler))
         .route("/api/color", post(routes::color::color_handler))
         .route("/api/room/{code}", get(routes::room::room_handler))

--- a/server/src/room.rs
+++ b/server/src/room.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use tokio::{sync::broadcast, task::JoinHandle};
 
 use crate::{
-    Coordinates, RoomEvent,
+    AppError, Coordinates, RoomEvent,
     colors::{DistinctColors, PlayerColor},
     event::{PlayerData, PlayerResult, RoundEndData, RoundStartData},
     geo::Location,
@@ -46,7 +46,7 @@ pub struct Room {
     /// The room's current [configuration](Config).
     // Currently unused, but will be used to implement different game modes and constraints in the future.
     #[allow(dead_code)]
-    config: Config,
+    pub config: Config,
     /// The event sender handle for the room, used to broadcast events to all members of the room.
     pub event_tx: broadcast::Sender<RoomEvent>,
     /// Number of live SSE connections subscribed to this room.
@@ -163,55 +163,65 @@ impl Room {
     /// Handle a ready submission from a member of the room.
     /// Returns true if everyone is ready.
     pub fn submit_ready(&mut self, client_id: &handle::Id) -> bool {
-        let Some(member) = self.members.get_mut(client_id) else {
-            return false;
-        };
+        let member = self
+            .members
+            .get_mut(client_id)
+            .expect("client routed here via client_room_mut must be a room member");
 
         member.ready_next_round = true;
 
         self.members.values().all(|m| m.ready_next_round)
     }
 
-    pub fn get_round_data(&self) -> RoundStartData {
-        RoundStartData {
-            pano_id: self.location.pano_id.clone(),
-            round: self.round,
-        }
-    }
+    /// Transition to next round
+    pub fn start_next_round(&mut self, new_location: Location) {
+        let pano_id = new_location.pano_id.clone();
 
-    fn reset_ready_status(&mut self) {
+        let round = match self.state {
+            State::Active { round, .. } => round + 1,
+            State::Inactive => 1,
+        };
+
+        self.state = State::Active {
+            round,
+            location: new_location,
+        };
+
+        let _ = self
+            .event_tx
+            .send(RoomEvent::RoundStart(RoundStartData { pano_id, round }));
+
+        // Reset ready status for next round
         for member in self.members.values_mut() {
             member.ready_next_round = false;
         }
     }
 
-    /// Transition to next round
-    pub fn start_next_round(&mut self, new_location: Location) {
-        let pano_id = new_location.pano_id.clone();
-        self.location = new_location;
-
-        // Reset ready status for next round
-        self.reset_ready_status();
-
-        self.round += 1;
-        let round = self.round;
-        let _ = self
-            .event_tx
-            .send(RoomEvent::RoundStart(RoundStartData { pano_id, round }));
-    }
-
     /// Handle a guess from a member of the room. This will update the member's score and broadcast
     /// if everyone has submitted a guess for the current round.
-    pub fn submit_guess(&mut self, client_id: &handle::Id, guess: Coordinates) {
-        let Some(member) = self.members.get_mut(client_id) else {
-            return;
+    pub fn submit_guess(
+        &mut self,
+        client_id: &handle::Id,
+        guess: Coordinates,
+    ) -> Result<(), AppError> {
+        let State::Active { location, .. } = &self.state else {
+            return Err(AppError::RoomInactive);
         };
+        let real_location = location.coordinates.clone();
 
-        let distance = score::haversine_distance(&guess, &self.location.coordinates);
-        let points = score::calculate_score(distance);
+        let distance = score::haversine_distance(&guess, &real_location);
+        let round_score = score::calculate_score(distance) as u32;
 
-        member.score += points as u32;
-        member.guess = Some(guess);
+        let member = self
+            .members
+            .get_mut(client_id)
+            .expect("client routed here via client_room_mut must be a room member");
+        member.score += round_score;
+        member.guess = Some(RoundGuess {
+            coordinates: guess,
+            distance,
+            round_score,
+        });
 
         // Check if everyone has guessed
         let all_guessed = self.members.values().all(|m| m.guess.is_some());
@@ -220,32 +230,41 @@ impl Room {
                 .members
                 .values()
                 .map(|m| {
-                    let guess_location = m.guess.clone().unwrap(); // Safe unwrap()
-                    let distance =
-                        score::haversine_distance(&guess_location, &self.location.coordinates);
-                    let round_score = score::calculate_score(distance) as u32;
+                    let g = m
+                        .guess
+                        .as_ref()
+                        .expect("all_guessed implies every member has a guess");
                     PlayerResult {
                         player: PlayerData::from(m),
-                        round_score,
-                        distance,
-                        guess_location,
+                        round_score: g.round_score,
+                        distance: g.distance,
+                        guess_location: g.coordinates.clone(),
                     }
                 })
                 .collect();
 
-            let event = RoomEvent::RoundEnd(RoundEndData {
-                real_location: self.location.coordinates.clone(),
-                player_results,
-            });
             // Broadcast round end event to all members of the room.
-            let _ = self.event_tx.send(event);
+            let _ = self.event_tx.send(RoomEvent::RoundEnd(RoundEndData {
+                real_location,
+                player_results,
+            }));
 
             // Reset guesses for next round
             for member in self.members.values_mut() {
                 member.guess = None;
             }
         }
+
+        Ok(())
     }
+}
+
+/// A player's guess for the current round, plus the derived distance and
+/// round-score so the round-end recap doesn't recompute them.
+pub struct RoundGuess {
+    pub coordinates: Coordinates,
+    pub distance: f64,
+    pub round_score: u32,
 }
 
 /// The attributes of a member of a [`Room`].
@@ -255,7 +274,7 @@ pub struct MemberAttributes {
     /// The current score of the member in the [`Room`].
     pub score: u32,
     /// The member's most recent guess for the current round, if they have submitted one.
-    pub guess: Option<Coordinates>,
+    pub guess: Option<RoundGuess>,
     /// The color assigned to the member for frontend display purposes.
     pub color: PlayerColor,
     /// Whether the member is ready to move on to the next round.

--- a/server/src/room.rs
+++ b/server/src/room.rs
@@ -114,6 +114,13 @@ impl Room {
         }
     }
 
+    /// Deactivate the room and notify all members
+    pub fn deactivate(&mut self) {
+        self.state = State::Inactive;
+
+        let _ = self.event_tx.send(RoomEvent::Deactivate);
+    }
+
     /// Add a member to the room. If `color` is not provided, a new distinct color is generated.
     pub fn add_member(
         &mut self,
@@ -134,7 +141,7 @@ impl Room {
 
         let new_member = MemberAttributes::new(username.clone(), color);
 
-        let event = RoomEvent::PlayerJoined(PlayerData::from(&new_member));
+        let event = RoomEvent::PlayerJoin(PlayerData::from(&new_member));
 
         self.members.insert(client_id.clone(), new_member);
 
@@ -155,7 +162,7 @@ impl Room {
         self.colors.remove_occupied(member.color.srgb);
 
         // Broadcast leave event
-        let _ = self.event_tx.send(RoomEvent::PlayerLeft {
+        let _ = self.event_tx.send(RoomEvent::PlayerLeave {
             username: member.username,
         });
     }

--- a/server/src/room.rs
+++ b/server/src/room.rs
@@ -13,24 +13,34 @@ use crate::{
     handle, score,
 };
 
-/// The length of a [`Room::Id`] identifier string.
+/// The length of a [`Id`] identifier string.
 const ROOM_ID_LENGTH: usize = 4;
 
 /// Used when [`DistinctColors`] is saturated and can't produce a fresh
 /// distinct color. (Rare)
 const FALLBACK_COLOR: Srgb8 = srgb!("#808080");
 
+pub enum State {
+    /// Rounds are currently being played
+    Active {
+        /// The number of rounds played
+        round: u32,
+        /// The room's current [`Location`].
+        location: Location,
+    },
+    /// Rounds are paused, members are joining
+    Inactive,
+}
+
 /// A room exists in a particular [`Location`], housing multiple members who are all
 /// at the room's location. A room's [`Config`] specifies the rules of how the room
 /// behaves, or the constraints applied to / advantages given to certain members.
 pub struct Room {
+    /// The state of the room ([`State::Active`] or [`State::Inactive`])
+    pub state: State,
     /// A map corresponding the identifiers of each member to their local
     /// [attributes](MemberAttributes).
     pub members: HashMap<handle::Id, MemberAttributes>,
-    /// The number of rounds played
-    pub round: usize,
-    /// The room's current [`Location`].
-    pub location: Location,
     /// A generator for distinct colors to assign to members of the room for frontend display purposes. The same color will be assigned to the same member across rounds, but different members will have different colors.
     pub colors: DistinctColors,
     /// The room's current [configuration](Config).
@@ -40,10 +50,9 @@ pub struct Room {
     /// The event sender handle for the room, used to broadcast events to all members of the room.
     pub event_tx: broadcast::Sender<RoomEvent>,
     /// Number of live SSE connections subscribed to this room.
-    active_connections: usize,
+    active_connections: u32,
     /// Handle to a cleanup task scheduled while the room is idle.
     cleanup_handle: Option<JoinHandle<()>>,
-    // TODO: location history for the round
 }
 
 impl Room {
@@ -67,9 +76,8 @@ impl Room {
         };
         let members = HashMap::from([(client_id, MemberAttributes::new(username, color))]);
         Self {
+            state: State::Active { round: 0, location },
             members,
-            round: 0,
-            location,
             colors,
             config: Config {},
             event_tx,
@@ -171,15 +179,19 @@ impl Room {
         }
     }
 
+    fn reset_ready_status(&mut self) {
+        for member in self.members.values_mut() {
+            member.ready_next_round = false;
+        }
+    }
+
     /// Transition to next round
     pub fn start_next_round(&mut self, new_location: Location) {
         let pano_id = new_location.pano_id.clone();
         self.location = new_location;
 
         // Reset ready status for next round
-        for member in self.members.values_mut() {
-            member.ready_next_round = false;
-        }
+        self.reset_ready_status();
 
         self.round += 1;
         let round = self.round;

--- a/server/src/routes.rs
+++ b/server/src/routes.rs
@@ -1,4 +1,5 @@
 pub mod color;
+pub mod deactivate;
 pub mod events;
 pub mod guess;
 pub mod init;

--- a/server/src/routes/color.rs
+++ b/server/src/routes/color.rs
@@ -1,14 +1,14 @@
-use axum::{Json, extract::State, http::StatusCode};
+use axum::{Json, extract::State};
 use colors::Srgb8;
 
-use crate::{Context, handle};
+use crate::{AppError, Context, handle};
 
 #[tracing::instrument(skip_all, fields(client_id = %*client_id))]
 pub async fn color_handler(
     State(context): State<Context>,
     client_id: handle::Id,
     Json(color): Json<Srgb8>,
-) -> Result<(), StatusCode> {
+) -> Result<(), AppError> {
     let mut model = context.model.write().await;
 
     model.set_color(&client_id, color)

--- a/server/src/routes/deactivate.rs
+++ b/server/src/routes/deactivate.rs
@@ -1,0 +1,18 @@
+use axum::extract::State;
+
+use crate::{AppError, Context, handle};
+
+#[tracing::instrument(skip_all, fields(client_id = %*client_id))]
+pub async fn deactivate_handler(
+    State(context): State<Context>,
+    client_id: handle::Id,
+) -> Result<(), AppError> {
+    context
+        .model
+        .write()
+        .await
+        .client_room_mut(&client_id)?
+        .deactivate();
+
+    Ok(())
+}

--- a/server/src/routes/events.rs
+++ b/server/src/routes/events.rs
@@ -1,6 +1,5 @@
 use std::pin::Pin;
 
-use axum::http::StatusCode;
 use axum::{
     extract::State,
     response::{Sse, sse},
@@ -9,7 +8,7 @@ use futures_util::{Stream, StreamExt};
 use tokio_stream::wrappers::BroadcastStream;
 use tracing::debug;
 
-use crate::{Context, RoomEvent, event::RoundStartData, handle, room};
+use crate::{AppError, Context, RoomEvent, event::RoundStartData, handle, room};
 
 #[pin_project::pin_project(PinnedDrop)]
 pub struct EventStream<S> {
@@ -49,19 +48,18 @@ impl<S> PinnedDrop for EventStream<S> {
 pub async fn sse_event_handler(
     State(context): State<Context>,
     client_id: handle::Id,
-) -> Result<Sse<impl Stream<Item = Result<sse::Event, axum::Error>>>, StatusCode> {
+) -> Result<Sse<impl Stream<Item = Result<sse::Event, axum::Error>>>, AppError> {
     let mut model = context.model.write().await;
     let handle = model
         .clients
         .get(&client_id)
-        .ok_or(StatusCode::UNAUTHORIZED)?;
+        .ok_or(AppError::UnknownClient)?;
     let room_id = handle.room.clone();
-    let room = model.rooms.get_mut(&room_id).ok_or(StatusCode::NOT_FOUND)?;
+    let room = model
+        .rooms
+        .get_mut(&room_id)
+        .ok_or(AppError::RoomNotFound)?;
     room.connect();
-
-    let round = room.round;
-    let pano_id = room.location.pano_id.clone();
-    let initial_event = RoomEvent::RoundStart(RoundStartData { pano_id, round });
 
     let rx = room.event_tx.subscribe();
 
@@ -85,7 +83,13 @@ pub async fn sse_event_handler(
         room_id,
     };
 
-    room.event_tx.send(initial_event).unwrap();
+    if let room::State::Active { round, location } = &room.state {
+        let initial_event = RoomEvent::RoundStart(RoundStartData {
+            pano_id: location.pano_id.clone(),
+            round: *round,
+        });
+        let _ = room.event_tx.send(initial_event);
+    }
 
     Ok(Sse::new(event_stream))
 }

--- a/server/src/routes/guess.rs
+++ b/server/src/routes/guess.rs
@@ -1,18 +1,15 @@
-use axum::http::StatusCode;
 use axum::{Json, extract::State};
 
-use crate::{Context, Coordinates, handle};
+use crate::{AppError, Context, Coordinates, handle};
 
 #[tracing::instrument(skip_all, fields(client_id = %*client_id))]
 pub async fn guess_handler(
     State(context): State<Context>,
     client_id: handle::Id,
     Json(guess): Json<Coordinates>,
-) -> Result<(), StatusCode> {
+) -> Result<(), AppError> {
     let mut model = context.model.write().await;
 
     let room = model.client_room_mut(&client_id)?;
-    room.submit_guess(&client_id, guess);
-
-    Ok(())
+    room.submit_guess(&client_id, guess)
 }

--- a/server/src/routes/init.rs
+++ b/server/src/routes/init.rs
@@ -1,9 +1,8 @@
-use axum::http::StatusCode;
 use axum::{Json, extract::State};
 use axum_extra::extract::CookieJar;
 use colors::Srgb8;
 
-use crate::{Context, handle, room};
+use crate::{AppError, Context, handle, room};
 
 #[derive(serde::Deserialize, Default)]
 pub struct InitRequest {
@@ -23,11 +22,12 @@ pub async fn init_handler(
     State(context): State<Context>,
     jar: CookieJar,
     Json(request): Json<InitRequest>,
-) -> Result<(CookieJar, Json<InitResponse>), StatusCode> {
+) -> Result<(CookieJar, Json<InitResponse>), AppError> {
     let (jar, client_id) = match jar.get(handle::ID_COOKIE_NAME) {
         Some(c) => {
-            let client_id =
-                handle::Id::try_from(c.value()).map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+            let client_id = handle::Id::try_from(c.value()).map_err(|e| {
+                AppError::Internal(anyhow::anyhow!("invalid client id cookie: {e}"))
+            })?;
             (jar, client_id)
         }
         None => {
@@ -36,11 +36,7 @@ pub async fn init_handler(
         }
     };
 
-    let location = context
-        .engine
-        .get_random_location()
-        .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    let location = context.engine.get_random_location().await?;
 
     let (room_id, username, color) = context
         .create_room(location, client_id.clone(), request.username, request.color)

--- a/server/src/routes/join.rs
+++ b/server/src/routes/join.rs
@@ -1,15 +1,14 @@
-use axum::http::StatusCode;
 use axum::{Json, extract::State};
 
 use crate::event::PlayerData;
-use crate::{Context, handle, room};
+use crate::{AppError, Context, handle, room};
 
 #[tracing::instrument(skip_all, fields(client_id = %*client_id))]
 pub async fn join_handler(
     State(context): State<Context>,
     client_id: handle::Id,
     Json(room_id): Json<room::Id>,
-) -> Result<Json<Vec<PlayerData>>, StatusCode> {
+) -> Result<Json<Vec<PlayerData>>, AppError> {
     let players = context.move_client_to_room(&client_id, &room_id).await?;
 
     Ok(Json(players))

--- a/server/src/routes/next.rs
+++ b/server/src/routes/next.rs
@@ -1,13 +1,12 @@
 use axum::extract::State;
-use axum::http::StatusCode;
 
-use crate::{Context, handle};
+use crate::{AppError, Context, handle};
 
 #[tracing::instrument(skip_all, fields(client_id = %*client_id))]
 pub async fn next_handler(
     State(context): State<Context>,
     client_id: handle::Id,
-) -> Result<(), StatusCode> {
+) -> Result<(), AppError> {
     let start_new_round = {
         let mut model = context.model.write().await;
         let room = model.client_room_mut(&client_id)?;
@@ -15,10 +14,7 @@ pub async fn next_handler(
     };
 
     if start_new_round {
-        let new_location = context.engine.get_random_location().await.map_err(|e| {
-            tracing::error!(%e, "failed to get new location for next round");
-            StatusCode::INTERNAL_SERVER_ERROR
-        })?;
+        let new_location = context.engine.get_random_location().await?;
 
         let mut model = context.model.write().await;
         if let Ok(room) = model.client_room_mut(&client_id) {

--- a/server/src/routes/room.rs
+++ b/server/src/routes/room.rs
@@ -1,17 +1,15 @@
-use anyhow::Result;
 use axum::{
     Json,
     extract::{Path, State},
 };
-use reqwest::StatusCode;
 
-use crate::{Context, event::PlayerData, room};
+use crate::{AppError, Context, event::PlayerData, room};
 
 #[tracing::instrument(skip_all, fields(room_id = %*room_id))]
 pub async fn room_handler(
     State(context): State<Context>,
     Path(room_id): Path<room::Id>,
-) -> Result<Json<Vec<PlayerData>>, StatusCode> {
+) -> Result<Json<Vec<PlayerData>>, AppError> {
     let players = context.get_room_players(&room_id).await?;
     Ok(Json(players))
 }

--- a/server/src/routes/username.rs
+++ b/server/src/routes/username.rs
@@ -1,13 +1,13 @@
-use axum::{Json, extract::State, http::StatusCode};
+use axum::{Json, extract::State};
 
-use crate::{Context, handle};
+use crate::{AppError, Context, handle};
 
 #[tracing::instrument(skip_all, fields(client_id = %*client_id))]
 pub async fn username_handler(
     State(context): State<Context>,
     client_id: handle::Id,
     Json(username): Json<String>,
-) -> Result<(), StatusCode> {
+) -> Result<(), AppError> {
     let mut model = context.model.write().await;
 
     model.set_name(&client_id, username)


### PR DESCRIPTION
## New Routes
- `/api/deactivate`: **POST** to set room to inactive

## New Events
- `deactivate`: broadcast when the room your in is set to inactive.

Fixes #46 