### PR TITLE
Broadcast room configuration changes

### DIFF
--- a/server/src/event.rs
+++ b/server/src/event.rs
@@ -1,6 +1,6 @@
 use std::collections::HashSet;
 
-use crate::{Coordinates, geo::PanoId, handle};
+use crate::{Coordinates, geo::PanoId, handle, room};
 use axum::response::sse;
 use colors::Srgb8;
 use serde::Serialize;
@@ -55,6 +55,7 @@ pub enum RoomEvent {
         client_id: handle::Id,
         username: Username,
     },
+    ConfigUpdate(room::Config),
 }
 
 impl RoomEvent {
@@ -64,7 +65,7 @@ impl RoomEvent {
             Self::PlayerJoined { client_id, .. } | Self::PlayerLeft { client_id, .. } => {
                 Recipients::except_one(client_id.clone())
             }
-            Self::RoundStart(_) | Self::RoundEnd(_) => Recipients::All,
+            Self::RoundStart(_) | Self::RoundEnd(_) | Self::ConfigUpdate(_) => Recipients::All,
         }
     }
 }

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -49,6 +49,7 @@ async fn main() -> anyhow::Result<()> {
         .route("/api/username", post(routes::username::username_handler))
         .route("/api/color", post(routes::color::color_handler))
         .route("/api/room/{code}", get(routes::room::room_handler))
+        .route("/api/config", post(routes::config::config_handler))
         .with_state(cx)
         .layer(TraceLayer::new_for_http())
         .fallback_service(ServeDir::new(&config.web_dir));

--- a/server/src/room.rs
+++ b/server/src/room.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use colors::{Srgb8, srgb};
 use derive_more::{AsRef, Deref};
 use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
 use tokio::{sync::broadcast, task::JoinHandle};
 
 use crate::{
@@ -34,8 +35,6 @@ pub struct Room {
     /// A generator for distinct colors to assign to members of the room for frontend display purposes. The same color will be assigned to the same member across rounds, but different members will have different colors.
     pub colors: DistinctColors,
     /// The room's current [configuration](Config).
-    // Currently unused, but will be used to implement different game modes and constraints in the future.
-    #[allow(dead_code)]
     config: Config,
     /// The event sender handle for the room, used to broadcast events to all members of the room.
     pub event_tx: broadcast::Sender<EventEnvelope>,
@@ -71,7 +70,7 @@ impl Room {
             round: 0,
             location,
             colors,
-            config: Config {},
+            config: Config::default(),
             event_tx,
             active_connections: 0,
             cleanup_handle: None,
@@ -256,6 +255,11 @@ impl Room {
             member.guess = None;
         }
     }
+
+    pub fn set_config(&mut self, config: Config) {
+        self.config = config.clone();
+        let _ = self.event_tx.send(RoomEvent::ConfigUpdate(config).into());
+    }
 }
 
 /// The attributes of a member of a [`Room`].
@@ -336,4 +340,9 @@ impl FromIterator<char> for Id {
 }
 
 /// The configuration of a [`Room`].
-pub struct Config {}
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct Config {
+    /// Anything we dont care to deserialize
+    #[serde(flatten)]
+    pub extra: Map<String, Value>,
+}

--- a/server/src/routes.rs
+++ b/server/src/routes.rs
@@ -1,4 +1,5 @@
 pub mod color;
+pub mod config;
 pub mod events;
 pub mod guess;
 pub mod init;

--- a/server/src/routes/config.rs
+++ b/server/src/routes/config.rs
@@ -1,0 +1,16 @@
+use axum::{Json, extract::State, http::StatusCode};
+
+use crate::{Context, handle, room};
+
+#[tracing::instrument(skip_all, fields(client_id = %*client_id))]
+pub async fn config_handler(
+    State(context): State<Context>,
+    client_id: handle::Id,
+    Json(config): Json<room::Config>,
+) -> Result<(), StatusCode> {
+    let mut model = context.model.write().await;
+
+    model.client_room_mut(&client_id)?.set_config(config);
+
+    Ok(())
+}


### PR DESCRIPTION
## New Routes
- `/api/config`: *POST* json of room configuration

## New Events
- `config-update`: broadcast when any room configuration update is received.
  - contains the same json sent by the original client

Closes #79 